### PR TITLE
Fix perl version check in eg/xml

### DIFF
--- a/eg/xml
+++ b/eg/xml
@@ -91,7 +91,7 @@ my @passes = $iss->pass( $start_time, $start_time + $days * 86400 );
 # Put the output into UTF-8 mode, since that is what we intend to use.
 # This gets eval'ed to hide it if we're using Perl 5.6.
 
-$] ge '5.008'
+$] >= 5.008
     and eval "binmode STDOUT, ':encoding(utf-8)'";
 
 # Now fire up the XML generator.


### PR DESCRIPTION
`$]` is a number and must be compared as a number. A test like `$] ge '5.008'` will start failing once `$]` reaches (or exceeds) 10.0.