### PR TITLE
Fix perl version check in Astro::Coord::ECI::Utils

### DIFF
--- a/lib/Astro/Coord/ECI/Utils.pm
+++ b/lib/Astro/Coord/ECI/Utils.pm
@@ -1617,7 +1617,7 @@ sub __sprintf {
     my ( $tplt, @args ) = @_;
     defined $tplt
 	or return undef;	## no critic (ProhibitExplicitReturnUndef)
-    no if $] gt '5.021002', qw{ warnings redundant };
+    no if $] > 5.021002, qw{ warnings redundant };
     return sprintf $tplt, @args;
 }
 


### PR DESCRIPTION
`$]` is a number and must be compared as a number. A test like `$] gt '5.021002'` will start failing once `$]` reaches (or exceeds) 10.0.